### PR TITLE
fix: improve comment color contrast across all themes

### DIFF
--- a/apps/ghostty/shenzhen-nights
+++ b/apps/ghostty/shenzhen-nights
@@ -9,7 +9,7 @@ palette = 4=1A8CFF
 palette = 5=CC33FF
 palette = 6=00CCFF
 palette = 7=b8c2cc
-palette = 8=485058
+palette = 8=6B7D8C
 palette = 9=FF5C8A
 palette = 10=20e0a0
 palette = 11=FFDA3B

--- a/apps/helix/themes/shenzhen-nights.toml
+++ b/apps/helix/themes/shenzhen-nights.toml
@@ -231,7 +231,7 @@ color6 = "#00CCFF"
 color7 = "#b8c2cc"
 
 # ANSI colors (Bright)
-color8 = "#485058"
+color8 = "#6B7D8C"
 color9 = "#FF5C8A"
 color10 = "#20e0a0"
 color11 = "#FFDA3B"

--- a/apps/kitty/shenzhen.conf
+++ b/apps/kitty/shenzhen.conf
@@ -6,7 +6,7 @@ foreground #d8dce0
 background #0a0f14
 
 color0 #101820
-color8 #485058
+color8 #6B7D8C
 
 color1 #FF3366
 color9 #FF5C8A

--- a/apps/vscode/themes/shenzhen-color-theme.json
+++ b/apps/vscode/themes/shenzhen-color-theme.json
@@ -7,14 +7,14 @@
     "editorCursor.foreground": "#FFCC00",
     "editor.selectionBackground": "#2a384c",
     "editor.selectionHighlightBackground": "#1A8CFF33",
-    "editorWhitespace.foreground": "#485058",
-    "editorIndentGuide.background1": "#485058",
+    "editorWhitespace.foreground": "#6B7D8C",
+    "editorIndentGuide.background1": "#6B7D8C",
     "editorIndentGuide.activeBackground1": "#b8c2cc",
-    "editorLineNumber.foreground": "#485058",
+    "editorLineNumber.foreground": "#6B7D8C",
     "editorLineNumber.activeForeground": "#b8c2cc",
     "activityBar.background": "#0a0f14",
     "activityBar.foreground": "#d8dce0",
-    "activityBar.inactiveForeground": "#485058",
+    "activityBar.inactiveForeground": "#6B7D8C",
     "activityBarBadge.background": "#00cc99",
     "activityBarBadge.foreground": "#0a0f14",
     "sideBar.background": "#101820",
@@ -35,7 +35,7 @@
     "titleBar.activeBackground": "#0a0f14",
     "titleBar.activeForeground": "#d8dce0",
     "titleBar.inactiveBackground": "#0a0f14",
-    "titleBar.inactiveForeground": "#485058",
+    "titleBar.inactiveForeground": "#6B7D8C",
     "tab.activeBackground": "#0a0f14",
     "tab.inactiveBackground": "#101820",
     "tab.activeForeground": "#e5e9f0",
@@ -45,18 +45,18 @@
     "tab.border": "#101820",
     "input.background": "#101820",
     "input.foreground": "#d8dce0",
-    "input.border": "#485058",
+    "input.border": "#6B7D8C",
     "inputOption.activeBorder": "#00cc99",
     "inputValidation.infoBorder": "#1A8CFF",
     "inputValidation.warningBorder": "#FFCC00",
     "inputValidation.errorBorder": "#FF3366",
     "dropdown.background": "#101820",
-    "dropdown.border": "#485058",
+    "dropdown.border": "#6B7D8C",
     "button.background": "#1A8CFF",
     "button.foreground": "#0a0f14",
     "button.hoverBackground": "#57A5FF",
     "panel.background": "#101820",
-    "panel.border": "#485058",
+    "panel.border": "#6B7D8C",
     "panelTitle.activeBorder": "#00cc99",
     "panelTitle.activeForeground": "#e5e9f0",
     "panelTitle.inactiveForeground": "#b8c2cc",
@@ -70,7 +70,7 @@
     "terminal.ansiMagenta": "#CC33FF",
     "terminal.ansiCyan": "#00CCFF",
     "terminal.ansiWhite": "#b8c2cc",
-    "terminal.ansiBrightBlack": "#485058",
+    "terminal.ansiBrightBlack": "#6B7D8C",
     "terminal.ansiBrightRed": "#FF5C8A",
     "terminal.ansiBrightGreen": "#20e0a0",
     "terminal.ansiBrightYellow": "#FFDA3B",
@@ -93,7 +93,7 @@
     {
       "scope": ["comment", "punctuation.definition.comment", "string.comment"],
       "settings": {
-        "foreground": "#485058",
+        "foreground": "#6B7D8C",
         "fontStyle": "italic"
       }
     },
@@ -286,7 +286,7 @@
         "scope": "markup.quote",
         "settings": {
             "fontStyle": "italic",
-            "foreground": "#485058"
+            "foreground": "#6B7D8C"
         }
     },
     {

--- a/apps/warp/shenzhen-nights.yaml
+++ b/apps/warp/shenzhen-nights.yaml
@@ -5,7 +5,7 @@ foreground: '#d8dce0'
 details: darker
 terminal_colors:
   bright:
-    black: '#485058'
+    black: '#6B7D8C'
     blue: '#57A5FF'
     cyan: '#40e0ff'
     green: '#20e0a0'

--- a/palette/colors.yaml
+++ b/palette/colors.yaml
@@ -19,7 +19,7 @@ color6: "#00CCFF"  # Vivid Sky Blue from image
 color7: "#b8c2cc"  # White (Kept)
 
 # ANSI colors (Bright) - Adjusted brighter versions based on image colors
-color8: "#485058"   # Bright Black (Slightly lighter Gray)
+color8: "#6B7D8C"   # Bright Black (Improved contrast for comments)
 color9: "#FF5C8A"   # Bright Red/Pink
 color10: "#20e0a0"  # Bright Green/Cyan (Kept original bright)
 color11: "#FFDA3B"  # Bright Yellow/Orange


### PR DESCRIPTION
Fixes comment color contrast issue by changing from #485058 to #6B7D8C

This change improves readability of comments across all supported editors:
- VS Code
- Helix
- Kitty terminal
- Warp terminal
- Ghostty terminal

Fixes #1

Generated with [Claude Code](https://claude.ai/code)