### PR TITLE
fix: resolve VSCode extension CI workflow warnings

### DIFF
--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -1,0 +1,111 @@
+# Development files
+.vscode/**
+.vscode-test/**
+.gitignore
+.gitattributes
+
+# Node.js
+node_modules/**
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build artifacts
+out/**
+dist/**
+.build/**
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.test
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# next.js build output
+.next
+
+# nuxt.js build output
+.nuxt
+
+# vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Linux
+*~
+
+# Source control
+.git/**
+.svn/**
+.hg/**
+
+# Testing
+test/**
+tests/**
+*.test.*
+*.spec.*
+
+# Documentation (keep only essential docs)
+docs/**
+*.md
+!README.md
+
+# Package files
+*.vsix
+vsc-extension-quickstart.md


### PR DESCRIPTION
…ning

- Add comprehensive .vscodeignore file for VSCode extension
- Excludes development files, node_modules, build artifacts, and OS-specific files
- Resolves workflow warning about missing .vscodeignore file